### PR TITLE
Seed de steel estava com um bloco que não tem crafting

### DIFF
--- a/scripts/Mod Specific Scripts/Mystical Agriculture/Mystical Seeds.zs
+++ b/scripts/Mod Specific Scripts/Mystical Agriculture/Mystical Seeds.zs
@@ -718,9 +718,9 @@ mods.extendedcrafting.TableCrafting.addShaped(3, <mysticalagriculture:steel_seed
 	[<ore:blockSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:blockSteel>], 
 	[<ore:ingotSteel>, <extendedcrafting:material:7>, <ore:blockCoal>, <ore:blockIron>, <ore:blockCoal>, <extendedcrafting:material:7>, <ore:ingotSteel>], 
 	[<ore:ingotSteel>, <ore:blockIron>, <ore:essenceTier3>, <ore:essenceSuperium>, <ore:essenceTier3>, <ore:blockIron>, <ore:ingotSteel>], 
-	[<ore:ingotSteel>, <ore:blockCoal>, <ore:essenceSuperium>, <mysticalagriculture:crafting:20>, <ore:essenceSuperium>, <ore:blockCoalCoke>, <ore:ingotSteel>], 
+	[<ore:ingotSteel>, <ore:blockCoal>, <ore:essenceSuperium>, <mysticalagriculture:crafting:20>, <ore:essenceSuperium>, <ore:blockFuelCoke>, <ore:ingotSteel>], 
 	[<ore:ingotSteel>, <ore:blockIron>, <ore:essenceTier3>, <ore:essenceSuperium>, <ore:essenceTier3>, <ore:blockIron>, <ore:ingotSteel>], 
-	[<ore:ingotSteel>, <extendedcrafting:material:7>, <ore:blockCoalCoke>, <ore:blockIron>, <ore:blockCoalCoke>, <extendedcrafting:material:7>, <ore:ingotSteel>], 
+	[<ore:ingotSteel>, <extendedcrafting:material:7>, <ore:blockFuelCoke>, <ore:blockIron>, <ore:blockFuelCoke>, <extendedcrafting:material:7>, <ore:ingotSteel>], 
 	[<ore:blockSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:ingotSteel>, <ore:blockSteel>]
 ]);
 


### PR DESCRIPTION
Devido a esse bug, apresentado pelo `dilannetwork`.

![image](https://user-images.githubusercontent.com/9171169/99155794-0378ce80-269a-11eb-82ec-f78917b8fef6.png)

Eu troquei o oreDict da receita para aceitar o `blockFuelCoke` que possui a receita (usa 9 coal coke)